### PR TITLE
Add spherical harmonics stability test

### DIFF
--- a/scripts/numerical_stability.py
+++ b/scripts/numerical_stability.py
@@ -1,0 +1,40 @@
+"""Check regression stability for spherical harmonics basis."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from geospectra import BasisFunctionRegressor, SphericalHarmonicsBasis
+
+
+def evaluate_degree(degree: int, rng: np.random.Generator) -> tuple[float, float]:
+    """Return residual and coefficient error for a given degree."""
+    n_features = (degree + 1) * (degree + 2) // 2
+    lon = rng.uniform(-np.pi, np.pi, size=n_features)
+    lat = rng.uniform(-np.pi / 2, np.pi / 2, size=n_features)
+    X = np.column_stack([lon, lat])
+    basis = SphericalHarmonicsBasis(
+        degree=degree,
+        cup=True,
+        include_bias=True,
+        force_norm=True,
+    )
+    design = basis.fit_transform(X)
+    coef_true = rng.normal(size=n_features)
+    y = design @ coef_true
+    reg = BasisFunctionRegressor(fit_intercept=False)
+    reg.fit(design, y)
+    residual = np.linalg.norm(reg.predict(design) - y)
+    coef_err = np.linalg.norm(reg.coef_ - coef_true)
+    return residual, coef_err
+
+
+def main() -> None:
+    rng = np.random.default_rng(0)
+    for degree in range(1, 51):
+        residual, coef_err = evaluate_degree(degree, rng)
+        print(f"degree={degree:2d} residual={residual:.2e} coef_error={coef_err:.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from geospectra import SphericalHarmonicsBasis, BasisFunctionRegressor
+
+
+def generate_data(
+    degree: int, rng: np.random.Generator
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Generate design matrix and target for a given spherical harmonic degree."""
+    n_features = (degree + 1) * (degree + 2) // 2
+    lon = rng.uniform(-np.pi, np.pi, size=n_features)
+    lat = rng.uniform(-np.pi / 2, np.pi / 2, size=n_features)
+    X = np.column_stack([lon, lat])
+    basis = SphericalHarmonicsBasis(
+        degree=degree,
+        cup=True,
+        include_bias=True,
+        force_norm=True,
+    )
+    design = basis.fit_transform(X)
+    coef = rng.normal(size=n_features)
+    y = design @ coef
+    return design, y, coef
+
+
+@pytest.mark.parametrize("degree", [1, 5, 10])
+def test_spherical_regressor_stability(degree: int) -> None:
+    rng = np.random.default_rng(degree)
+    design, y, coef = generate_data(degree, rng)
+    reg = BasisFunctionRegressor(fit_intercept=False)
+    reg.fit(design, y)
+    y_pred = reg.predict(design)
+    assert np.allclose(y_pred, y, atol=1e-10)
+    assert np.allclose(reg.coef_, coef, atol=1e-10)


### PR DESCRIPTION
## Summary
- add a utility script to inspect the numerical stability of the spherical harmonic regressor
- add regression unit tests on a few spherical harmonic degrees

## Testing
- `ruff format tests/test_stability.py scripts/numerical_stability.py`
- `ruff check tests/test_stability.py scripts/numerical_stability.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5801e7b8832bbba795e10c90557f