### PR TITLE
Improve sklearn compatibility

### DIFF
--- a/src/geospectra/basis.py
+++ b/src/geospectra/basis.py
@@ -223,6 +223,10 @@ class SphericalHarmonicsBasis(TransformerMixin, BaseEstimator):
             StrOptions({"auto"}),
             Interval(RealNotInt, 0, 1, closed="right"),
         ],
+        "force_norm": ["boolean"],
+        "coords_convert_method": [
+            StrOptions({"central_scale", "central", "basic", "non"})
+        ],
     }
 
     def __init__(
@@ -320,7 +324,7 @@ class SphericalHarmonicsBasis(TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self, "coords_convert")
 
-        X = validate_data(self, X, accept_sparse=True)
+        X = validate_data(self, X, accept_sparse=True, reset=False)
         lon, lat = X[:, 0], X[:, 1]
         theta, phi = self.coords_convert.transform(lon, lat)
 
@@ -369,6 +373,7 @@ class SphericalHarmonicsBasis(TransformerMixin, BaseEstimator):
         feature_names : ndarray of str
             Transformed feature names.
         """
+        input_features = _check_feature_names_in(self, input_features)
         feature_names = []
         for order in range(self.degree + 1):
             if order == 0 and not self.include_bias:

--- a/tests/test_sklearn_api.py
+++ b/tests/test_sklearn_api.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from geospectra import SphericalHarmonicsBasis
+
+
+def test_transform_checks_feature_count() -> None:
+    rng = np.random.default_rng(0)
+    X = rng.random((5, 2))
+    basis = SphericalHarmonicsBasis()
+    basis.fit(X)
+    with pytest.raises(ValueError):
+        basis.transform(rng.random((2, 3)))
+
+
+def test_transform_checks_feature_names() -> None:
+    rng = np.random.default_rng(1)
+    X = pd.DataFrame(rng.random((5, 2)), columns=["lon", "lat"])
+    basis = SphericalHarmonicsBasis()
+    basis.fit(X)
+    X_bad = pd.DataFrame(rng.random((2, 2)), columns=["x", "y"])
+    with pytest.raises(ValueError):
+        basis.transform(X_bad)
+
+
+def test_get_feature_names_out_validates_features() -> None:
+    rng = np.random.default_rng(2)
+    X = pd.DataFrame(rng.random((5, 2)), columns=["lon", "lat"])
+    basis = SphericalHarmonicsBasis()
+    basis.fit(X)
+    with pytest.raises(ValueError):
+        basis.get_feature_names_out(["x", "y"])

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -14,8 +14,8 @@ def generate_data(
         include_bias=False,
     )
 
-    lon = rng.uniform(-180, 180, size=(degree+1)**2*2)
-    lat = rng.uniform(-90, 90, size=(degree+1)**2*2)
+    lon = rng.uniform(-180, 180, size=(degree + 1) ** 2 * 2)
+    lat = rng.uniform(-90, 90, size=(degree + 1) ** 2 * 2)
     X = np.column_stack([lon, lat])
 
     design = basis.fit_transform(X)
@@ -29,7 +29,7 @@ def generate_data(
     return design, y, coef, intercept
 
 
-@pytest.mark.parametrize("degree", [5,10, 25, 40])
+@pytest.mark.parametrize("degree", [5, 10, 25, 40])
 def test_spherical_regressor_stability(degree: int) -> None:
     rng = np.random.default_rng(degree)
     design, y, coef, intercept = generate_data(degree, rng)


### PR DESCRIPTION
## Summary
- expose all SphericalHarmonics parameters for sklearn's parameter validation
- preserve `n_features_in_` during `transform`
- check feature names in `get_feature_names_out`
- add sklearn API regression tests

## Testing
- `ruff format .`
- `ruff check .`
- `pytest tests/test_sklearn_api.py::test_transform_checks_feature_count -q`
- `pytest tests/test_stability.py::test_spherical_regressor_stability[5] -q`
- `pytest tests/test_stability.py::test_spherical_regressor_stability[10] -q`
- `pytest tests/test_stability.py::test_spherical_regressor_stability[25] -q`
- `pytest tests/test_stability.py::test_spherical_regressor_stability[40] -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_686b95000cb8832ba459a9edc9316df6