### PR TITLE
Update estimators for latest scikit-learn APIs

### DIFF
--- a/src/geospectra/basis.py
+++ b/src/geospectra/basis.py
@@ -50,10 +50,11 @@ class PolynomialBasis(TransformerMixin, BaseEstimator):
 
     def __init__(
         self,
+        *,
         degree=2,
         include_bias=True,
         basis="polynomial",
-    ):
+    ) -> None:
         self.degree = degree
         self.include_bias = include_bias
         self.basis = basis
@@ -227,6 +228,7 @@ class SphericalHarmonicsBasis(TransformerMixin, BaseEstimator):
 
     def __init__(
         self,
+        *,
         degree=2,
         pole="xyzmean",
         cup=True,
@@ -234,7 +236,7 @@ class SphericalHarmonicsBasis(TransformerMixin, BaseEstimator):
         hemisphere_scale="auto",
         force_norm=False,
         coords_convert_method="central_scale",
-    ):
+    ) -> None:
         self.degree = degree
         self.pole = pole
         self.cup = cup

--- a/src/geospectra/linear_model.py
+++ b/src/geospectra/linear_model.py
@@ -36,6 +36,10 @@ class LinearRegressionCond(LinearRegression):
         )
         self.cond_threshold = cond_threshold  # 新增可调超参数
 
+    def get_metadata_routing(self):
+        """Return metadata routing from the parent estimator."""
+        return super().get_metadata_routing()
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, sample_weight=None):
         """

--- a/src/geospectra/transforms.py
+++ b/src/geospectra/transforms.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 
 class PCA:
-    def __init__(self, criteria="normal"):
+    def __init__(self, *, criteria="normal") -> None:
         self.mean_ = None
         self.feature_names_in_ = None
         self.n_features = None

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -14,8 +14,8 @@ def generate_data(
         include_bias=False,
     )
 
-    lon = rng.uniform(-180, 180, size=(degree+1)**2*2)
-    lat = rng.uniform(-90, 90, size=(degree+1)**2*2)
+    lon = rng.uniform(-180, 180, size=(degree + 1) ** 2 * 2)
+    lat = rng.uniform(-90, 90, size=(degree + 1) ** 2 * 2)
     X = np.column_stack([lon, lat])
 
     design = basis.fit_transform(X)
@@ -29,7 +29,7 @@ def generate_data(
     return design, y, coef, intercept
 
 
-@pytest.mark.parametrize("degree", [5,10, 25, 40])
+@pytest.mark.parametrize("degree", [5, 10, 25, 40])
 def test_spherical_regressor_stability(degree: int) -> None:
     rng = np.random.default_rng(degree)
     design, y, coef, intercept = generate_data(degree, rng)


### PR DESCRIPTION
## Summary
- make estimator initializers keyword-only
- expose metadata routing in `LinearRegressionCond`
- style fixes in stability tests

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .` *(fails: missing type stubs)*
- `pytest tests/test_linear_model.py::test_polynomial_fit_predict_multi_target -q`

------
https://chatgpt.com/codex/tasks/task_e_686b955d786c832ba9a1ce86a6eec8a8