### PR TITLE
feat: fix scaling factor persistence

### DIFF
--- a/src/geospectra/basis.py
+++ b/src/geospectra/basis.py
@@ -424,6 +424,11 @@ class CoordsConverter:
             raise ValueError(
                 "Pole must be a tuple of two floats or ['haversine','xyzmean']."
             )
+
+        if self.method == "central_scale":
+            theta1, _ = self._central(lon, lat)
+            self.scale = np.pi * self.hemisphere_scale / theta1.max()
+
         return self
 
     def transform(self, lon, lat):
@@ -581,8 +586,8 @@ class CoordsConverter:
         return theta1, phi1
 
     def _central_scale(self, lon, lat):
-        theta1, phi1 = self._central(lon, lat)
         if self.scale is None:
-            self.scale = np.pi * self.hemisphere_scale / theta1.max()
+            raise AttributeError("scale is None, please call the fit method first")
+        theta1, phi1 = self._central(lon, lat)
         theta_scale = theta1 * self.scale
         return theta_scale, phi1

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -12,3 +12,24 @@ def test_transform_handles_pole_point() -> None:
     theta, phi = conv.transform(np.array([lon0]), np.array([lat0]))
     assert not np.isnan(phi).any()
     assert np.allclose(phi, 0.0)
+
+
+def test_central_scale_consistent() -> None:
+    rng = np.random.default_rng(0)
+    lon = rng.uniform(-180, 180, size=10)
+    lat = rng.uniform(-90, 90, size=10)
+
+    conv = CoordsConverter(pole="xyzmean", method="central_scale")
+    conv.fit(lon, lat)
+    scale_after_fit = conv.scale
+
+    conv.transform(lon, lat)
+    scale_after_first = conv.scale
+
+    lon2 = rng.uniform(-180, 180, size=5)
+    lat2 = rng.uniform(-90, 90, size=5)
+    conv.transform(lon2, lat2)
+    scale_after_second = conv.scale
+
+    assert np.allclose(scale_after_fit, scale_after_first)
+    assert np.allclose(scale_after_first, scale_after_second)


### PR DESCRIPTION
## Summary
- preserve scaling factor during CoordsConverter.fit
- test CoordsConverter scaling factor remains constant

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb23b32f4832b9badd92bdd88fd1a